### PR TITLE
fix: support remark flags

### DIFF
--- a/clang/warnings-10.txt
+++ b/clang/warnings-10.txt
@@ -970,11 +970,11 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
--Wmodule-import
+-Rmodule-import
 -Wmodule-import-in-extern-c
 -Wmodules-ambiguous-internal-linkage
 -Wmodules-import-nested-redundant
@@ -1228,10 +1228,10 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -1339,7 +1339,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 #   -Wreorder-ctor
 #   -Wreorder-init-list
@@ -1357,7 +1357,7 @@
 -Wreturn-type
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-11.txt
+++ b/clang/warnings-11.txt
@@ -988,11 +988,11 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
--Wmodule-import
+-Rmodule-import
 -Wmodule-import-in-extern-c
 -Wmodules-ambiguous-internal-linkage
 -Wmodules-import-nested-redundant
@@ -1252,10 +1252,10 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -1371,7 +1371,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 #   -Wreorder-ctor
 #   -Wreorder-init-list
@@ -1390,7 +1390,7 @@
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
 -Wrewrite-not-bool
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-12.txt
+++ b/clang/warnings-12.txt
@@ -1008,11 +1008,11 @@
 -Wmissing-sysroot
 -Wmissing-variable-declarations
 -Wmisspelled-assumption
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
--Wmodule-import
+-Rmodule-import
 -Wmodule-import-in-extern-c
 -Wmodules-ambiguous-internal-linkage
 -Wmodules-import-nested-redundant
@@ -1273,10 +1273,10 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -1390,7 +1390,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 #   -Wreorder-ctor
 #   -Wreorder-init-list
@@ -1410,7 +1410,7 @@
 -Wreturn-type-c-linkage
 -Wrewrite-not-bool
 -Wrtti
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-13.txt
+++ b/clang/warnings-13.txt
@@ -1073,11 +1073,11 @@
 -Wmissing-sysroot
 -Wmissing-variable-declarations
 -Wmisspelled-assumption
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
--Wmodule-import
+-Rmodule-import
 -Wmodule-import-in-extern-c
 -Wmodules-ambiguous-internal-linkage
 -Wmodules-import-nested-redundant
@@ -1342,10 +1342,10 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -1476,7 +1476,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 #   -Wreorder-ctor
 #   -Wreorder-init-list
@@ -1498,9 +1498,9 @@
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
 -Wrewrite-not-bool
--Wround-trip-cc1-args
+-Rround-trip-cc1-args
 -Wrtti
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-3.5.txt
+++ b/clang/warnings-3.5.txt
@@ -488,7 +488,7 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmost
 #   -Wcast-of-sel-type
@@ -634,10 +634,10 @@
 #   -Wparentheses-equality
 #   -Wshift-op-parentheses
 -Wparentheses-equality
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc11-extensions
@@ -699,7 +699,7 @@
 -Wredeclared-class-member
 -Wredundant-decls # DUMMY switch
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute
 -Wreserved-user-defined-literal

--- a/clang/warnings-3.6.txt
+++ b/clang/warnings-3.6.txt
@@ -508,7 +508,7 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmost
 #   -Wcast-of-sel-type
@@ -659,10 +659,10 @@
 #   -Wparentheses-equality
 #   -Wshift-op-parentheses
 -Wparentheses-equality
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc11-extensions
@@ -728,7 +728,7 @@
 -Wredeclared-class-member
 -Wredundant-decls # DUMMY switch
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute
 -Wreserved-id-macro
@@ -739,7 +739,7 @@
 -Wreturn-type
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-3.7.txt
+++ b/clang/warnings-3.7.txt
@@ -527,7 +527,7 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmost
 #   -Wcast-of-sel-type
@@ -696,10 +696,10 @@
 #   -Wshift-op-parentheses
 -Wparentheses-equality
 -Wpartial-availability
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc11-extensions
@@ -771,7 +771,7 @@
 -Wredundant-decls # DUMMY switch
 -Wredundant-move
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute
 -Wreserved-id-macro
@@ -783,7 +783,7 @@
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
 -Wrtti-for-exceptions
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-3.8.txt
+++ b/clang/warnings-3.8.txt
@@ -685,7 +685,7 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
@@ -863,10 +863,10 @@
 #   -Wshift-op-parentheses
 -Wparentheses-equality
 -Wpartial-availability
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -954,7 +954,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute
 -Wreserved-id-macro
@@ -966,7 +966,7 @@
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
 -Wrtti-for-exceptions
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-3.9.txt
+++ b/clang/warnings-3.9.txt
@@ -696,7 +696,7 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
@@ -879,10 +879,10 @@
 #   -Wshift-op-parentheses
 -Wparentheses-equality
 -Wpartial-availability
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -970,7 +970,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute
 -Wreserved-id-macro
@@ -982,7 +982,7 @@
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
 -Wrtti-for-exceptions
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-4.txt
+++ b/clang/warnings-4.txt
@@ -718,7 +718,7 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
@@ -907,10 +907,10 @@
 -Wparentheses-equality
 -Wpartial-availability
 #   -Wunguarded-availability
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -1000,7 +1000,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute
 -Wreserved-id-macro
@@ -1012,7 +1012,7 @@
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
 -Wrtti-for-exceptions
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-5.txt
+++ b/clang/warnings-5.txt
@@ -742,7 +742,7 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
@@ -938,10 +938,10 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -1034,7 +1034,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute
 -Wreserved-id-macro
@@ -1046,7 +1046,7 @@
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
 -Wrtti-for-exceptions
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-6.txt
+++ b/clang/warnings-6.txt
@@ -798,7 +798,7 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
@@ -1001,10 +1001,10 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -1102,7 +1102,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute
 -Wreserved-id-macro
@@ -1114,7 +1114,7 @@
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
 -Wrtti-for-exceptions
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-7.txt
+++ b/clang/warnings-7.txt
@@ -819,7 +819,7 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
@@ -1027,10 +1027,10 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -1129,7 +1129,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute
 -Wreserved-id-macro
@@ -1142,7 +1142,7 @@
 -Wreturn-type
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-8.txt
+++ b/clang/warnings-8.txt
@@ -843,7 +843,7 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
@@ -1059,10 +1059,10 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -1163,7 +1163,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute
 -Wreserved-id-macro
@@ -1176,7 +1176,7 @@
 -Wreturn-type
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-9.txt
+++ b/clang/warnings-9.txt
@@ -855,11 +855,11 @@
 -Wmissing-selector-name
 -Wmissing-sysroot
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict
 -Wmodule-file-config-mismatch
 -Wmodule-file-extension
--Wmodule-import
+-Rmodule-import
 -Wmodule-import-in-extern-c
 -Wmodules-ambiguous-internal-linkage
 -Wmodules-import-nested-redundant
@@ -1075,10 +1075,10 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time
 -Wpedantic
 #   -Wc++11-extra-semi
@@ -1179,7 +1179,7 @@
 -Wregister
 #   -Wdeprecated-register
 -Wreinterpret-base-class
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute
 -Wreserved-id-macro
@@ -1192,7 +1192,7 @@
 -Wreturn-type
 #   -Wreturn-type-c-linkage
 -Wreturn-type-c-linkage
--Wsanitize-address
+-Rsanitize-address
 -Wsection
 -Wselector
 #   -Wselector-type-mismatch

--- a/clang/warnings-diff-12-13.txt
+++ b/clang/warnings-diff-12-13.txt
@@ -31,7 +31,7 @@
 --Wreturn-std-move
 --Wreturn-std-move-in-c++11
 +-Wreturn-std-move # DUMMY switch
-+-Wround-trip-cc1-args
++-Rround-trip-cc1-args
 +-Wsource-mgr # Enabled by default.
 +-Wtautological-unsigned-char-zero-compare
 +-Wunused-but-set-parameter

--- a/clang/warnings-diff-3.4-3.5.txt
+++ b/clang/warnings-diff-3.4-3.5.txt
@@ -39,7 +39,7 @@
 +-Wmain # Partially enabled by default.
 +-Wmemsize-comparison # Enabled by default.
 --Wmismatched-method-attributes # Enabled by default.
-+-Wmodule-build
++-Rmodule-build
 +-Wmsvc-include # Enabled by default.
 +-Wnew-returns-null # Enabled by default.
 +-Wnon-modular-include-in-framework-module
@@ -52,16 +52,16 @@
 +-Wold-style-cast
 +-Wopenmp-clauses # Enabled by default.
 +-Wopenmp-loop-form # Enabled by default.
-+-Wpass
-+-Wpass-analysis
++-Rpass
++-Rpass-analysis
 +-Wpass-failed # Enabled by default.
-+-Wpass-missed
++-Rpass-missed
 +-Wpointer-bool-conversion # Enabled by default.
 +-Wpragmas # Partially enabled by default.
 +-Wprofile-instr-out-of-date # Enabled by default.
 +-Wprofile-instr-unprofiled # Enabled by default.
 --Wreadonly-setter-attrs
-+-Wremark-backend-plugin
++-Rremark-backend-plugin
 +-Wswitch-bool # Enabled by default.
 --Wtautological-compare # Enabled by default.
 +-Wtautological-compare # Partially enabled by default.

--- a/clang/warnings-diff-3.5-3.6.txt
+++ b/clang/warnings-diff-3.5-3.6.txt
@@ -22,7 +22,7 @@
 +-Wproperty-access-dot-syntax # Enabled by default.
 +-Wproperty-attribute-mismatch # Enabled by default.
 +-Wreserved-id-macro
-+-Wsanitize-address
++-Rsanitize-address
 +-Wself-move
 +-Wsync-fetch-and-nand-semantics-changed # Enabled by default.
 +-Wthread-safety-negative

--- a/clang/warnings-diff-8-9.txt
+++ b/clang/warnings-diff-8-9.txt
@@ -7,7 +7,7 @@
 +-Wimplicit-fixed-point-conversion # Enabled by default.
 +-Wincomplete-setjmp-declaration # Enabled by default.
 +-Wmicrosoft-drectve-section # Enabled by default.
-+-Wmodule-import
++-Rmodule-import
 +-Wobjc-bool-constant-conversion # Enabled by default.
 +-Wobjc-boxing # Enabled by default.
 +-Wtautological-objc-bool-compare # Enabled by default.

--- a/clang/warnings-messages-10.txt
+++ b/clang/warnings-messages-10.txt
@@ -3086,12 +3086,12 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     could not acquire lock file for module 'A': B
 #     finished building module 'A'
 #     timed out waiting to acquire lock file for module 'A'
--Wmodule-import
+-Rmodule-import
 #     importing module 'A'[ into 'D'] from 'B'
 -Wnarrowing
 #   -Wc++11-narrowing
@@ -3263,13 +3263,13 @@
 #         A is only available on B C or newer
 #     -Wunguarded-availability-new
 #           A is only available on B C or newer
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -3513,7 +3513,7 @@
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
 #     redundant parentheses surrounding declarator
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -3523,7 +3523,7 @@
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
 -Wreturn-std-move-in-c++11
 #     prior to the resolution of a defect report against ISO C++11, local variable A would have been copied despite being returned by name, due to its not matching the function return type
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-11.txt
+++ b/clang/warnings-messages-11.txt
@@ -3171,12 +3171,12 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     could not acquire lock file for module 'A': B
 #     finished building module 'A'
 #     timed out waiting to acquire lock file for module 'A'
--Wmodule-import
+-Rmodule-import
 #     importing module 'A'[ into 'D'] from 'B'
 -Wnarrowing
 #   -Wc++11-narrowing
@@ -3360,13 +3360,13 @@
 #         A is only available on B C or newer
 #     -Wunguarded-availability-new
 #           A is only available on B C or newer
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -3610,7 +3610,7 @@
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
 #     redundant parentheses surrounding declarator
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -3620,7 +3620,7 @@
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
 -Wreturn-std-move-in-c++11
 #     prior to the resolution of a defect report against ISO C++11, local variable A would have been copied despite being returned by name, due to its not matching the function return type
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-12.txt
+++ b/clang/warnings-messages-12.txt
@@ -3249,12 +3249,12 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     could not acquire lock file for module 'A': B
 #     finished building module 'A'
 #     timed out waiting to acquire lock file for module 'A'
--Wmodule-import
+-Rmodule-import
 #     importing module 'A'[ into 'D'] from 'B'
 -Wnarrowing
 #   -Wc++11-narrowing
@@ -3439,13 +3439,13 @@
 #         A is only available on B C or newer
 #     -Wunguarded-availability-new
 #           A is only available on B C or newer
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -3684,7 +3684,7 @@
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
 #     redundant parentheses surrounding declarator
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -3694,7 +3694,7 @@
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
 -Wreturn-std-move-in-c++11
 #     prior to the resolution of a defect report against ISO C++11, local variable A would have been copied despite being returned by name, due to its not matching the function return type
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-13.txt
+++ b/clang/warnings-messages-13.txt
@@ -3526,12 +3526,12 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     could not acquire lock file for module 'A': B
 #     finished building module 'A'
 #     timed out waiting to acquire lock file for module 'A'
--Wmodule-import
+-Rmodule-import
 #     importing module 'A'[ into 'D'] from 'B'
 -Wnarrowing
 #   -Wc++11-narrowing
@@ -3719,13 +3719,13 @@
 #         A is only available on B C or newer
 #     -Wunguarded-availability-new
 #           A is only available on B C or newer
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -3971,7 +3971,7 @@
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
 #     redundant parentheses surrounding declarator
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #   -Wreserved-macro-identifier
@@ -3984,9 +3984,9 @@
 #     invalid suffix on literal; C++11 requires a space between literal and identifier
 #   -Wc++11-compat-reserved-user-defined-literal
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
--Wround-trip-cc1-args
+-Rround-trip-cc1-args
 #     Generated arguments #A in round-trip: B
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-3.5.txt
+++ b/clang/warnings-messages-3.5.txt
@@ -1665,7 +1665,7 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 -Wnarrowing
 #   -Wc++11-narrowing
@@ -1756,11 +1756,11 @@
 #     padding <struct|interface|class> B with C <byte|bit>[s] to align F
 #     padding <struct|interface|class> B with C <byte|bit>[s] to align anonymous bit-field
 #     padding size of A with B <byte|bit>[s] to alignment boundary
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -1949,7 +1949,7 @@
 -Wreceiver-is-weak
 #     weak <receiver|property|implicit property> may be unpredictably set to nil
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-user-defined-literal
 #     invalid suffix on literal; C++11 requires a space between literal and identifier

--- a/clang/warnings-messages-3.6.txt
+++ b/clang/warnings-messages-3.6.txt
@@ -1754,7 +1754,7 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     finished building module 'A'
 -Wnarrowing
@@ -1843,11 +1843,11 @@
 #     padding <struct|interface|class> B with C <byte|bit>[s] to align F
 #     padding <struct|interface|class> B with C <byte|bit>[s] to align anonymous bit-field
 #     padding size of A with B <byte|bit>[s] to alignment boundary
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -2038,7 +2038,7 @@
 -Wreceiver-is-weak
 #     weak <receiver|property|implicit property> may be unpredictably set to nil
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -2046,7 +2046,7 @@
 #     invalid suffix on literal; C++11 requires a space between literal and identifier
 #   -Wc++11-compat-reserved-user-defined-literal
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-3.7.txt
+++ b/clang/warnings-messages-3.7.txt
@@ -1849,7 +1849,7 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     finished building module 'A'
 -Wnarrowing
@@ -1945,11 +1945,11 @@
 #     A is only available conditionally
 #     A is partial: B
 #     A may be partial because the receiver type is unknown
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -2141,7 +2141,7 @@
 #     receiver type A for instance message is a forward declaration
 -Wreceiver-is-weak # DUMMY switch
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -2149,7 +2149,7 @@
 #     invalid suffix on literal; C++11 requires a space between literal and identifier
 #   -Wc++11-compat-reserved-user-defined-literal
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-3.8.txt
+++ b/clang/warnings-messages-3.8.txt
@@ -2002,7 +2002,7 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     finished building module 'A'
 -Wnarrowing
@@ -2098,13 +2098,13 @@
 #     A is only available conditionally
 #     A is partial: B
 #     A may be partial because the receiver type is unknown
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -2322,7 +2322,7 @@
 #     receiver type A for instance message is a forward declaration
 -Wreceiver-is-weak # DUMMY switch
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -2330,7 +2330,7 @@
 #     invalid suffix on literal; C++11 requires a space between literal and identifier
 #   -Wc++11-compat-reserved-user-defined-literal
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-3.9.txt
+++ b/clang/warnings-messages-3.9.txt
@@ -2104,7 +2104,7 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     finished building module 'A'
 -Wnarrowing
@@ -2206,13 +2206,13 @@
 #     A is only available conditionally
 #     A is partial: B
 #     A may be partial because the receiver type is unknown
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -2432,7 +2432,7 @@
 #     receiver A is a forward class and corresponding @interface may not exist
 #     receiver type A for instance message is a forward declaration
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -2440,7 +2440,7 @@
 #     invalid suffix on literal; C++11 requires a space between literal and identifier
 #   -Wc++11-compat-reserved-user-defined-literal
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-4.txt
+++ b/clang/warnings-messages-4.txt
@@ -2218,7 +2218,7 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     finished building module 'A'
 -Wnarrowing
@@ -2320,13 +2320,13 @@
 #         A is only available on B C or newer
 #         A is partial: B
 #         A may be partial because the receiver type is unknown
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -2550,7 +2550,7 @@
 #     receiver A is a forward class and corresponding @interface may not exist
 #     receiver type A for instance message is a forward declaration
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -2558,7 +2558,7 @@
 #     invalid suffix on literal; C++11 requires a space between literal and identifier
 #   -Wc++11-compat-reserved-user-defined-literal
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-5.txt
+++ b/clang/warnings-messages-5.txt
@@ -2270,7 +2270,7 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     could not acquire lock file for module 'A': B
 #     finished building module 'A'
@@ -2383,13 +2383,13 @@
 #           A is only available on B C or newer
 #           A is partial: B
 #           A may be partial because the receiver type is unknown
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -2616,7 +2616,7 @@
 #     receiver A is a forward class and corresponding @interface may not exist
 #     receiver type A for instance message is a forward declaration
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -2624,7 +2624,7 @@
 #     invalid suffix on literal; C++11 requires a space between literal and identifier
 #   -Wc++11-compat-reserved-user-defined-literal
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-6.txt
+++ b/clang/warnings-messages-6.txt
@@ -2475,7 +2475,7 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     could not acquire lock file for module 'A': B
 #     finished building module 'A'
@@ -2584,13 +2584,13 @@
 #         A is only available on B C or newer
 #     -Wunguarded-availability-new
 #           A is only available on B C or newer
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -2821,7 +2821,7 @@
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
 #     redundant parentheses surrounding declarator
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -2829,7 +2829,7 @@
 #     invalid suffix on literal; C++11 requires a space between literal and identifier
 #   -Wc++11-compat-reserved-user-defined-literal
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-7.txt
+++ b/clang/warnings-messages-7.txt
@@ -2542,7 +2542,7 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     could not acquire lock file for module 'A': B
 #     finished building module 'A'
@@ -2654,13 +2654,13 @@
 #         A is only available on B C or newer
 #     -Wunguarded-availability-new
 #           A is only available on B C or newer
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -2897,7 +2897,7 @@
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
 #     redundant parentheses surrounding declarator
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -2907,7 +2907,7 @@
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
 -Wreturn-std-move-in-c++11
 #     prior to the resolution of a defect report against ISO C++11, local variable A would have been copied despite being returned by name, due to its not matching the function return type
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-8.txt
+++ b/clang/warnings-messages-8.txt
@@ -2674,7 +2674,7 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     could not acquire lock file for module 'A': B
 #     finished building module 'A'
@@ -2793,13 +2793,13 @@
 #         A is only available on B C or newer
 #     -Wunguarded-availability-new
 #           A is only available on B C or newer
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -3038,7 +3038,7 @@
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
 #     redundant parentheses surrounding declarator
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -3048,7 +3048,7 @@
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
 -Wreturn-std-move-in-c++11
 #     prior to the resolution of a defect report against ISO C++11, local variable A would have been copied despite being returned by name, due to its not matching the function return type
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-messages-9.txt
+++ b/clang/warnings-messages-9.txt
@@ -2799,12 +2799,12 @@
 #     no previous prototype for function A
 -Wmissing-variable-declarations
 #     no previous extern declaration for non-static variable A
--Wmodule-build
+-Rmodule-build
 #     building module 'A' as 'B'
 #     could not acquire lock file for module 'A': B
 #     finished building module 'A'
 #     timed out waiting to acquire lock file for module 'A'
--Wmodule-import
+-Rmodule-import
 #     importing module 'A'[ into 'D'] from 'B'
 -Wnarrowing
 #   -Wc++11-narrowing
@@ -2922,13 +2922,13 @@
 #         A is only available on B C or newer
 #     -Wunguarded-availability-new
 #           A is only available on B C or newer
--Wpass
+-Rpass
 #     The text of this diagnostic is not controlled by Clang
--Wpass-analysis
+-Rpass-analysis
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'.
 #     A; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop. If the arrays will always be independent specify '#pragma clang loop vectorize(assume_safety)' before the loop or provide the '__restrict__' qualifier with the independent array arguments. Erroneous results will occur if these options are incorrectly applied!
 #     The text of this diagnostic is not controlled by Clang
--Wpass-missed
+-Rpass-missed
 #     The text of this diagnostic is not controlled by Clang
 -Wpedantic
 #     #ident is a language extension
@@ -3172,7 +3172,7 @@
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
 #     redundant parentheses surrounding declarator
--Wremark-backend-plugin
+-Rremark-backend-plugin
 #     The text of this diagnostic is not controlled by Clang
 -Wreserved-id-macro
 #     macro name is a reserved identifier
@@ -3182,7 +3182,7 @@
 #         identifier after literal will be treated as a reserved user-defined literal suffix in C++11
 -Wreturn-std-move-in-c++11
 #     prior to the resolution of a defect report against ISO C++11, local variable A would have been copied despite being returned by name, due to its not matching the function return type
--Wsanitize-address
+-Rsanitize-address
 #     -fsanitize-address-field-padding applied to A
 #     -fsanitize-address-field-padding ignored for A because it <is not C++|is packed|is a union|is trivially copyable|has trivial destructor|is standard layout|is in a blacklisted file|is blacklisted>
 -Wselector

--- a/clang/warnings-top-level-10.txt
+++ b/clang/warnings-top-level-10.txt
@@ -958,8 +958,8 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
--Wmodule-import
+-Rmodule-build
+-Rmodule-import
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -1027,9 +1027,9 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -1100,12 +1100,12 @@
 -Wreceiver-forward-class
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
 -Wreturn-std-move-in-c++11
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow-all

--- a/clang/warnings-top-level-11.txt
+++ b/clang/warnings-top-level-11.txt
@@ -988,8 +988,8 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
--Wmodule-import
+-Rmodule-build
+-Rmodule-import
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -1058,9 +1058,9 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -1130,12 +1130,12 @@
 -Wreceiver-forward-class
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
 -Wreturn-std-move-in-c++11
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow-all

--- a/clang/warnings-top-level-12.txt
+++ b/clang/warnings-top-level-12.txt
@@ -1009,8 +1009,8 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
--Wmodule-import
+-Rmodule-build
+-Rmodule-import
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -1079,9 +1079,9 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -1149,12 +1149,12 @@
 -Wreceiver-forward-class
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
 -Wreturn-std-move-in-c++11
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow-all

--- a/clang/warnings-top-level-13.txt
+++ b/clang/warnings-top-level-13.txt
@@ -1069,8 +1069,8 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
--Wmodule-import
+-Rmodule-build
+-Rmodule-import
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -1140,9 +1140,9 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -1213,15 +1213,15 @@
 -Wreceiver-forward-class
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 #   -Wreserved-macro-identifier
 -Wreserved-identifier
 #   -Wreserved-macro-identifier
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
--Wround-trip-cc1-args
--Wsanitize-address
+-Rround-trip-cc1-args
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow-all

--- a/clang/warnings-top-level-3.5.txt
+++ b/clang/warnings-top-level-3.5.txt
@@ -533,7 +533,7 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -570,9 +570,9 @@
 -Woverriding-method-mismatch
 -Wpacked
 -Wpadded
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc11-extensions
@@ -621,7 +621,7 @@
 -Wreceiver-forward-class
 -Wreceiver-is-weak
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
 -Wselector

--- a/clang/warnings-top-level-3.6.txt
+++ b/clang/warnings-top-level-3.6.txt
@@ -557,7 +557,7 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -592,9 +592,9 @@
 -Woverriding-method-mismatch
 -Wpacked
 -Wpadded
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc11-extensions
@@ -644,11 +644,11 @@
 -Wreceiver-forward-class
 -Wreceiver-is-weak
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow

--- a/clang/warnings-top-level-3.7.txt
+++ b/clang/warnings-top-level-3.7.txt
@@ -587,7 +587,7 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -624,9 +624,9 @@
 -Wpacked
 -Wpadded
 -Wpartial-availability
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc11-extensions
@@ -677,11 +677,11 @@
 -Wreceiver-forward-class
 -Wreceiver-is-weak # DUMMY switch
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow

--- a/clang/warnings-top-level-3.8.txt
+++ b/clang/warnings-top-level-3.8.txt
@@ -680,7 +680,7 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -717,9 +717,9 @@
 -Wpacked
 -Wpadded
 -Wpartial-availability
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -781,11 +781,11 @@
 -Wreceiver-forward-class
 -Wreceiver-is-weak # DUMMY switch
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow

--- a/clang/warnings-top-level-3.9.txt
+++ b/clang/warnings-top-level-3.9.txt
@@ -695,7 +695,7 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -735,9 +735,9 @@
 -Wpacked
 -Wpadded
 -Wpartial-availability
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -799,11 +799,11 @@
 #   -Wunknown-pragmas
 -Wreceiver-forward-class
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow-all

--- a/clang/warnings-top-level-4.txt
+++ b/clang/warnings-top-level-4.txt
@@ -721,7 +721,7 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -761,9 +761,9 @@
 -Wpadded
 -Wpartial-availability
 #   -Wunguarded-availability
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -826,11 +826,11 @@
 #   -Wunknown-pragmas
 -Wreceiver-forward-class
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow-all

--- a/clang/warnings-top-level-5.txt
+++ b/clang/warnings-top-level-5.txt
@@ -745,7 +745,7 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -787,9 +787,9 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -854,11 +854,11 @@
 -Wprofile-instr-missing
 -Wreceiver-forward-class
 -Wredundant-decls # DUMMY switch
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow-all

--- a/clang/warnings-top-level-6.txt
+++ b/clang/warnings-top-level-6.txt
@@ -814,7 +814,7 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -857,9 +857,9 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -926,11 +926,11 @@
 -Wreceiver-forward-class
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow-all

--- a/clang/warnings-top-level-7.txt
+++ b/clang/warnings-top-level-7.txt
@@ -833,7 +833,7 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -876,9 +876,9 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -946,12 +946,12 @@
 -Wreceiver-forward-class
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
 -Wreturn-std-move-in-c++11
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow-all

--- a/clang/warnings-top-level-8.txt
+++ b/clang/warnings-top-level-8.txt
@@ -852,7 +852,7 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -898,9 +898,9 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -969,12 +969,12 @@
 -Wreceiver-forward-class
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
 -Wreturn-std-move-in-c++11
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow-all

--- a/clang/warnings-top-level-9.txt
+++ b/clang/warnings-top-level-9.txt
@@ -866,8 +866,8 @@
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmissing-variable-declarations
--Wmodule-build
--Wmodule-import
+-Rmodule-build
+-Rmodule-import
 -Wnarrowing
 #   -Wc++11-narrowing
 -Wnested-externs # DUMMY switch
@@ -914,9 +914,9 @@
 -Wpartial-availability
 #   -Wunguarded-availability
 #     -Wunguarded-availability-new
--Wpass
--Wpass-analysis
--Wpass-missed
+-Rpass
+-Rpass-analysis
+-Rpass-missed
 -Wpedantic
 #   -Wc++11-extra-semi
 #   -Wc++14-binary-literal
@@ -985,12 +985,12 @@
 -Wreceiver-forward-class
 -Wredundant-decls # DUMMY switch
 -Wredundant-parens
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreserved-id-macro
 -Wreserved-user-defined-literal
 #   -Wc++11-compat-reserved-user-defined-literal
 -Wreturn-std-move-in-c++11
--Wsanitize-address
+-Rsanitize-address
 -Wselector
 #   -Wselector-type-mismatch
 -Wshadow-all

--- a/clang/warnings-unique-10.txt
+++ b/clang/warnings-unique-10.txt
@@ -459,11 +459,11 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
--Wmodule-import
+-Rmodule-import
 -Wmodule-import-in-extern-c # Enabled by default.
 -Wmodules-ambiguous-internal-linkage # Enabled by default.
 -Wmodules-import-nested-redundant # Enabled by default.
@@ -572,10 +572,10 @@
 -Wparentheses # Partially enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability # Partially enabled by default.
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpedantic-core-features
@@ -620,7 +620,7 @@
 -Wredundant-parens
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder # Partially enabled by default.
 -Wreorder-ctor
 -Wreorder-init-list # Enabled by default.
@@ -634,7 +634,7 @@
 -Wreturn-std-move-in-c++11
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-11.txt
+++ b/clang/warnings-unique-11.txt
@@ -471,11 +471,11 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
--Wmodule-import
+-Rmodule-import
 -Wmodule-import-in-extern-c # Enabled by default.
 -Wmodules-ambiguous-internal-linkage # Enabled by default.
 -Wmodules-import-nested-redundant # Enabled by default.
@@ -587,10 +587,10 @@
 -Wparentheses # Partially enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability # Partially enabled by default.
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpedantic-core-features
@@ -638,7 +638,7 @@
 -Wredundant-parens
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder # Partially enabled by default.
 -Wreorder-ctor
 -Wreorder-init-list # Enabled by default.
@@ -653,7 +653,7 @@
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
 -Wrewrite-not-bool # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-12.txt
+++ b/clang/warnings-unique-12.txt
@@ -479,11 +479,11 @@
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
 -Wmisspelled-assumption # Enabled by default.
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
--Wmodule-import
+-Rmodule-import
 -Wmodule-import-in-extern-c # Enabled by default.
 -Wmodules-ambiguous-internal-linkage # Enabled by default.
 -Wmodules-import-nested-redundant # Enabled by default.
@@ -595,10 +595,10 @@
 -Wparentheses # Partially enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability # Partially enabled by default.
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpedantic-core-features
@@ -646,7 +646,7 @@
 -Wredundant-parens
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder # Partially enabled by default.
 -Wreorder-ctor
 -Wreorder-init-list # Enabled by default.
@@ -662,7 +662,7 @@
 -Wreturn-type-c-linkage # Enabled by default.
 -Wrewrite-not-bool # Enabled by default.
 -Wrtti # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-13.txt
+++ b/clang/warnings-unique-13.txt
@@ -492,11 +492,11 @@
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
 -Wmisspelled-assumption # Enabled by default.
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
--Wmodule-import
+-Rmodule-import
 -Wmodule-import-in-extern-c # Enabled by default.
 -Wmodules-ambiguous-internal-linkage # Enabled by default.
 -Wmodules-import-nested-redundant # Enabled by default.
@@ -610,10 +610,10 @@
 -Wparentheses # Partially enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability # Partially enabled by default.
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpedantic-core-features
@@ -672,7 +672,7 @@
 -Wredundant-parens
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder # Partially enabled by default.
 -Wreorder-ctor
 -Wreorder-init-list # Enabled by default.
@@ -688,9 +688,9 @@
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
 -Wrewrite-not-bool # Enabled by default.
--Wround-trip-cc1-args
+-Rround-trip-cc1-args
 -Wrtti # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-3.5.txt
+++ b/clang/warnings-unique-3.5.txt
@@ -280,7 +280,7 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmost # Partially enabled by default.
 -Wmsvc-include # Enabled by default.
@@ -347,10 +347,10 @@
 -Wpadded
 -Wparentheses # Enabled by default.
 -Wparentheses-equality # Enabled by default.
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpedantic
 -Wpointer-arith # Partially enabled by default.
 -Wpointer-bool-conversion # Enabled by default.
@@ -371,7 +371,7 @@
 -Wredeclared-class-member # Enabled by default.
 -Wredundant-decls # DUMMY switch
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute # Enabled by default.
 -Wreserved-user-defined-literal # Partially enabled by default.

--- a/clang/warnings-unique-3.6.txt
+++ b/clang/warnings-unique-3.6.txt
@@ -293,7 +293,7 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmost # Partially enabled by default.
 -Wmsvc-include # Enabled by default.
@@ -361,10 +361,10 @@
 -Wpadded
 -Wparentheses # Enabled by default.
 -Wparentheses-equality # Enabled by default.
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpedantic
 -Wpointer-arith # Partially enabled by default.
 -Wpointer-bool-conversion # Enabled by default.
@@ -388,7 +388,7 @@
 -Wredeclared-class-member # Enabled by default.
 -Wredundant-decls # DUMMY switch
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute # Enabled by default.
 -Wreserved-id-macro
@@ -397,7 +397,7 @@
 -Wreturn-stack-address # Enabled by default.
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-3.7.txt
+++ b/clang/warnings-unique-3.7.txt
@@ -305,7 +305,7 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmost # Partially enabled by default.
 -Wmove
@@ -383,10 +383,10 @@
 -Wparentheses # Enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpedantic
 -Wpessimizing-move
 -Wpointer-arith # Partially enabled by default.
@@ -415,7 +415,7 @@
 -Wredundant-decls # DUMMY switch
 -Wredundant-move
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute # Enabled by default.
 -Wreserved-id-macro
@@ -425,7 +425,7 @@
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
 -Wrtti-for-exceptions # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-3.8.txt
+++ b/clang/warnings-unique-3.8.txt
@@ -348,7 +348,7 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
@@ -433,10 +433,10 @@
 -Wparentheses # Enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpessimizing-move
@@ -469,7 +469,7 @@
 -Wredundant-move
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute # Enabled by default.
 -Wreserved-id-macro
@@ -479,7 +479,7 @@
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
 -Wrtti-for-exceptions # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-3.9.txt
+++ b/clang/warnings-unique-3.9.txt
@@ -354,7 +354,7 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
@@ -442,10 +442,10 @@
 -Wparentheses # Enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpedantic-core-features
@@ -478,7 +478,7 @@
 -Wredundant-move
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute # Enabled by default.
 -Wreserved-id-macro
@@ -488,7 +488,7 @@
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
 -Wrtti-for-exceptions # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-4.txt
+++ b/clang/warnings-unique-4.txt
@@ -367,7 +367,7 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
@@ -458,10 +458,10 @@
 -Wparentheses # Enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpedantic-core-features
@@ -495,7 +495,7 @@
 -Wredundant-move
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute # Enabled by default.
 -Wreserved-id-macro
@@ -505,7 +505,7 @@
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
 -Wrtti-for-exceptions # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-5.txt
+++ b/clang/warnings-unique-5.txt
@@ -379,7 +379,7 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
@@ -473,10 +473,10 @@
 -Wparentheses # Enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability # Partially enabled by default.
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpedantic-core-features
@@ -512,7 +512,7 @@
 -Wredundant-move
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute # Enabled by default.
 -Wreserved-id-macro
@@ -522,7 +522,7 @@
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
 -Wrtti-for-exceptions # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-6.txt
+++ b/clang/warnings-unique-6.txt
@@ -391,7 +391,7 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
@@ -491,10 +491,10 @@
 -Wparentheses # Enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability # Partially enabled by default.
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpedantic-core-features
@@ -533,7 +533,7 @@
 -Wredundant-parens
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute # Enabled by default.
 -Wreserved-id-macro
@@ -543,7 +543,7 @@
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
 -Wrtti-for-exceptions # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-7.txt
+++ b/clang/warnings-unique-7.txt
@@ -401,7 +401,7 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
@@ -503,10 +503,10 @@
 -Wparentheses # Enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability # Partially enabled by default.
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpedantic-core-features
@@ -546,7 +546,7 @@
 -Wredundant-parens
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute # Enabled by default.
 -Wreserved-id-macro
@@ -557,7 +557,7 @@
 -Wreturn-std-move-in-c++11
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-8.txt
+++ b/clang/warnings-unique-8.txt
@@ -413,7 +413,7 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
@@ -518,10 +518,10 @@
 -Wparentheses # Enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability # Partially enabled by default.
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpedantic-core-features
@@ -562,7 +562,7 @@
 -Wredundant-parens
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute # Enabled by default.
 -Wreserved-id-macro
@@ -573,7 +573,7 @@
 -Wreturn-std-move-in-c++11
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/clang/warnings-unique-9.txt
+++ b/clang/warnings-unique-9.txt
@@ -422,11 +422,11 @@
 -Wmissing-selector-name # Enabled by default.
 -Wmissing-sysroot # Enabled by default.
 -Wmissing-variable-declarations
--Wmodule-build
+-Rmodule-build
 -Wmodule-conflict # Enabled by default.
 -Wmodule-file-config-mismatch # Enabled by default.
 -Wmodule-file-extension # Enabled by default.
--Wmodule-import
+-Rmodule-import
 -Wmodule-import-in-extern-c # Enabled by default.
 -Wmodules-ambiguous-internal-linkage # Enabled by default.
 -Wmodules-import-nested-redundant # Enabled by default.
@@ -530,10 +530,10 @@
 -Wparentheses # Enabled by default.
 -Wparentheses-equality # Enabled by default.
 -Wpartial-availability # Partially enabled by default.
--Wpass
--Wpass-analysis
+-Rpass
+-Rpass-analysis
 -Wpass-failed # Enabled by default.
--Wpass-missed
+-Rpass-missed
 -Wpch-date-time # Enabled by default.
 -Wpedantic
 -Wpedantic-core-features
@@ -574,7 +574,7 @@
 -Wredundant-parens
 -Wregister # Enabled by default.
 -Wreinterpret-base-class # Enabled by default.
--Wremark-backend-plugin
+-Rremark-backend-plugin
 -Wreorder
 -Wrequires-super-attribute # Enabled by default.
 -Wreserved-id-macro
@@ -585,7 +585,7 @@
 -Wreturn-std-move-in-c++11
 -Wreturn-type # Enabled by default.
 -Wreturn-type-c-linkage # Enabled by default.
--Wsanitize-address
+-Rsanitize-address
 -Wsection # Enabled by default.
 -Wselector
 -Wselector-type-mismatch

--- a/parsers/process_clang_git.py
+++ b/parsers/process_clang_git.py
@@ -108,7 +108,7 @@ def parse_clang_info(version: str, target_dir: str, input_dir: str) -> None:
     json_file = f"{target_dir}/warnings-{version}.json"
 
     shell(
-        ["llvm-tblgen-11", "-dump-json", "-I", input_dir, f"{input_dir}/Diagnostic.td"],
+        ["llvm-tblgen", "-dump-json", "-I", input_dir, f"{input_dir}/Diagnostic.td"],
         json_file,
     )
     format_json(json_file)

--- a/parsers/process_clang_git.py
+++ b/parsers/process_clang_git.py
@@ -108,7 +108,7 @@ def parse_clang_info(version: str, target_dir: str, input_dir: str) -> None:
     json_file = f"{target_dir}/warnings-{version}.json"
 
     shell(
-        ["llvm-tblgen", "-dump-json", "-I", input_dir, f"{input_dir}/Diagnostic.td"],
+        ["llvm-tblgen-11", "-dump-json", "-I", input_dir, f"{input_dir}/Diagnostic.td"],
         json_file,
     )
     format_json(json_file)


### PR DESCRIPTION
This would claim that clang supports
-Wsanitize-address
sanitize-address is actually a remark, so now it lists
-Rsanitize-address

I tested the new output for clang 11 against actual clang, running each
flag like "clang $flag -Werror -Wunknown-argument" and documenting if it
gave an error or not, and now it matches.
(except -Wframe-larger-than= because I didn't pass an argument and it
needed one)
